### PR TITLE
feat: add GroceryItemService with basic creation support

### DIFF
--- a/src/GroceryApi/Data/GroceryCategory.cs
+++ b/src/GroceryApi/Data/GroceryCategory.cs
@@ -1,0 +1,7 @@
+namespace GroceryApi.Data;
+
+public class GroceryCategory
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = null!;
+}

--- a/src/GroceryApi/Data/GroceryDbContext.cs
+++ b/src/GroceryApi/Data/GroceryDbContext.cs
@@ -6,6 +6,6 @@ public class GroceryDbContext : DbContext
 {
     public GroceryDbContext(DbContextOptions<GroceryDbContext> options) : base(options)
     {
-        throw new NotImplementedException();
     }
+    public DbSet<GroceryItem> GroceryItems { get; set; }
 }

--- a/src/GroceryApi/Data/GroceryDbContext.cs
+++ b/src/GroceryApi/Data/GroceryDbContext.cs
@@ -8,6 +8,7 @@ public class GroceryDbContext : DbContext
     {
     }
     public DbSet<GroceryItem> GroceryItems { get; set; }
+    public DbSet<GroceryCategory> GroceryCategories { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/GroceryApi/Data/GroceryDbContext.cs
+++ b/src/GroceryApi/Data/GroceryDbContext.cs
@@ -8,4 +8,12 @@ public class GroceryDbContext : DbContext
     {
     }
     public DbSet<GroceryItem> GroceryItems { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<GroceryItem>()
+            .HasIndex(b => new {b.Name, b.Price})
+            .IsUnique();
+    }
 }

--- a/src/GroceryApi/Data/GroceryDbContext.cs
+++ b/src/GroceryApi/Data/GroceryDbContext.cs
@@ -1,0 +1,11 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace GroceryApi.Data;
+
+public class GroceryDbContext : DbContext
+{
+    public GroceryDbContext(DbContextOptions<GroceryDbContext> options) : base(options)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/GroceryApi/Data/GroceryItem.cs
+++ b/src/GroceryApi/Data/GroceryItem.cs
@@ -7,7 +7,6 @@ public class GroceryItem
     public decimal Price { get; set; }
     public string Description { get; set; } = null!;
     public GroceryCategory? Category { get; set; } = null;
-    public int StockQuantity { get; set; } 
     
 
 }

--- a/src/GroceryApi/Data/GroceryItem.cs
+++ b/src/GroceryApi/Data/GroceryItem.cs
@@ -1,0 +1,13 @@
+namespace GroceryApi.Data;
+
+public class GroceryItem
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = null!;
+    public decimal Price { get; set; }
+    public string Description { get; set; } = null!;
+    public GroceryCategory? Category { get; set; } = null;
+    public int StockQuantity { get; set; } 
+    
+
+}

--- a/src/GroceryApi/Data/GroceryItem.cs
+++ b/src/GroceryApi/Data/GroceryItem.cs
@@ -6,6 +6,7 @@ public class GroceryItem
     public string Name { get; set; } = null!;
     public decimal Price { get; set; }
     public string Description { get; set; } = null!;
+    public int? CategoryId { get; set; } = null;
     public GroceryCategory? Category { get; set; } = null;
     
 

--- a/src/GroceryApi/GroceryApi.csproj
+++ b/src/GroceryApi/GroceryApi.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/src/GroceryApi/Services/GroceryItemService.cs
+++ b/src/GroceryApi/Services/GroceryItemService.cs
@@ -12,14 +12,14 @@ public class GroceryItemService
     }
 
     public async Task<GroceryItem?> CreateGroceryItemAsync(string name, decimal price, string description,
-        GroceryCategory? category = null)
+        int? categoryId = null)
     {
         GroceryItem? groceryItem = new GroceryItem
         {
             Name = name,
             Price = price,
             Description = description,
-            Category = category,
+            CategoryId = categoryId,
         };
         
         //Check constraints

--- a/src/GroceryApi/Services/GroceryItemService.cs
+++ b/src/GroceryApi/Services/GroceryItemService.cs
@@ -1,0 +1,20 @@
+using GroceryApi.Data;
+
+namespace GroceryApi.Services;
+
+public class GroceryItemService
+{
+    private readonly GroceryDbContext _context;
+
+    public GroceryItemService(GroceryDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<GroceryItem?> CreateGroceryItemAsync(string name, decimal price, string description,
+        GroceryCategory? category = null, int? stockQuantity = null)
+    {
+        return null;
+    }
+    
+}

--- a/src/GroceryApi/Services/GroceryItemService.cs
+++ b/src/GroceryApi/Services/GroceryItemService.cs
@@ -29,7 +29,7 @@ public class GroceryItemService
         var categoryExists = await _context.GroceryCategories.AnyAsync(i => 
             i.Id == groceryItem.CategoryId);
         
-        if (itemExists || !categoryExists)
+        if (itemExists || (!categoryExists&& categoryId.HasValue))
         {
             return null;
         }

--- a/src/GroceryApi/Services/GroceryItemService.cs
+++ b/src/GroceryApi/Services/GroceryItemService.cs
@@ -21,6 +21,14 @@ public class GroceryItemService
             Description = description,
             Category = category,
         };
+        
+        //Check constraints
+        var itemExists = _context.GroceryItems.Any(i => 
+            i.Name == groceryItem.Name && i.Price == groceryItem.Price);
+        if (itemExists)
+        {
+            return null;
+        }
         await  _context.AddAsync(groceryItem);
         await _context.SaveChangesAsync();
         return groceryItem;

--- a/src/GroceryApi/Services/GroceryItemService.cs
+++ b/src/GroceryApi/Services/GroceryItemService.cs
@@ -12,9 +12,18 @@ public class GroceryItemService
     }
 
     public async Task<GroceryItem?> CreateGroceryItemAsync(string name, decimal price, string description,
-        GroceryCategory? category = null, int? stockQuantity = null)
+        GroceryCategory? category = null)
     {
-        return null;
+        GroceryItem? groceryItem = new GroceryItem
+        {
+            Name = name,
+            Price = price,
+            Description = description,
+            Category = category,
+        };
+        await  _context.AddAsync(groceryItem);
+        await _context.SaveChangesAsync();
+        return groceryItem;
     }
     
 }

--- a/src/GroceryApi/Services/GroceryItemService.cs
+++ b/src/GroceryApi/Services/GroceryItemService.cs
@@ -1,4 +1,5 @@
 using GroceryApi.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace GroceryApi.Services;
 
@@ -23,9 +24,12 @@ public class GroceryItemService
         };
         
         //Check constraints
-        var itemExists = _context.GroceryItems.Any(i => 
+        var itemExists = await _context.GroceryItems.AnyAsync(i => 
             i.Name == groceryItem.Name && i.Price == groceryItem.Price);
-        if (itemExists)
+        var categoryExists = await _context.GroceryCategories.AnyAsync(i => 
+            i.Id == groceryItem.CategoryId);
+        
+        if (itemExists || !categoryExists)
         {
             return null;
         }

--- a/tests/GroceryApi.Tests/GroceryApi.Tests.csproj
+++ b/tests/GroceryApi.Tests/GroceryApi.Tests.csproj
@@ -10,7 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.17" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -20,6 +23,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GroceryApi\GroceryApi.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/GroceryApi.Tests/UnitTests/GroceryItemServiceTests.cs
+++ b/tests/GroceryApi.Tests/UnitTests/GroceryItemServiceTests.cs
@@ -1,0 +1,32 @@
+
+using GroceryApi.Data;
+using GroceryApi.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace GroceryApi.Tests.UnitTests;
+
+public class GroceryItemServiceTests
+{
+    [Fact]
+    public async Task CreateGroceryItem_Should_Create_GroceryItem()
+    {
+        var options = new DbContextOptionsBuilder<GroceryDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()) // unique DB per test
+            .Options;
+
+        using var context = new GroceryDbContext(options);
+        
+        var service = new GroceryItemService(context);
+        string itemName = "Cheddar cheese";
+        decimal price = 12m;
+        string description = "Yellow and delicious";
+        
+        GroceryItem? groceryItem = await service.CreateGroceryItemAsync(itemName, price, description);
+        Assert.NotNull(groceryItem);
+        
+        Assert.Equal(groceryItem.Name, itemName);
+        Assert.Equal(groceryItem.Price, price);
+        Assert.Equal(groceryItem.Description, description);
+
+    }
+}

--- a/tests/GroceryApi.Tests/UnitTests/GroceryItemServiceTests.cs
+++ b/tests/GroceryApi.Tests/UnitTests/GroceryItemServiceTests.cs
@@ -60,7 +60,7 @@ public class GroceryItemServiceTests
         string itemName = "Cheddar cheese";
         decimal price = 12m;
         string description = "Yellow and delicious";
-        var item = await service.CreateGroceryItemAsync(itemName, price, description, category: null);
+        var item = await service.CreateGroceryItemAsync(itemName, price, description, categoryId: null);
         Assert.NotNull(item);
     }
 
@@ -75,11 +75,8 @@ public class GroceryItemServiceTests
         string itemName = "Cheddar cheese";
         decimal price = 12m;
         string description = "Yellow and delicious";
-        GroceryCategory category = new GroceryCategory()
-        {
-            Name = "Fake category123"
-        };
-        var item = await service.CreateGroceryItemAsync(itemName, price, description,  category);
+        int cateogryId = 1;
+        var item = await service.CreateGroceryItemAsync(itemName, price, description,  cateogryId);
         Assert.Null(item);
     }
 

--- a/tests/GroceryApi.Tests/UnitTests/GroceryItemServiceTests.cs
+++ b/tests/GroceryApi.Tests/UnitTests/GroceryItemServiceTests.cs
@@ -49,4 +49,38 @@ public class GroceryItemServiceTests
 
     }
 
+    [Fact]
+    public async Task CreateGroceryItem_Allows_Null_Category()
+    {
+        var  options = new DbContextOptionsBuilder<GroceryDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        using var context = new GroceryDbContext(options);
+        var service = new GroceryItemService(context);
+        string itemName = "Cheddar cheese";
+        decimal price = 12m;
+        string description = "Yellow and delicious";
+        var item = await service.CreateGroceryItemAsync(itemName, price, description, category: null);
+        Assert.NotNull(item);
+    }
+
+    [Fact]
+    public async Task CreateGroceryItem_Should_ReturnNull_WhenCategoryDoesNotExist()
+    {
+        var  options = new DbContextOptionsBuilder<GroceryDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        using var context = new GroceryDbContext(options);
+        var service = new GroceryItemService(context);
+        string itemName = "Cheddar cheese";
+        decimal price = 12m;
+        string description = "Yellow and delicious";
+        GroceryCategory category = new GroceryCategory()
+        {
+            Name = "Fake category123"
+        };
+        var item = await service.CreateGroceryItemAsync(itemName, price, description,  category);
+        Assert.Null(item);
+    }
+
 }

--- a/tests/GroceryApi.Tests/UnitTests/GroceryItemServiceTests.cs
+++ b/tests/GroceryApi.Tests/UnitTests/GroceryItemServiceTests.cs
@@ -29,4 +29,24 @@ public class GroceryItemServiceTests
         Assert.Equal(groceryItem.Description, description);
 
     }
+
+    [Fact]
+    public async Task CreateGroceryItem_Should_Not_Allow_Duplicate_GroceryItems()
+    {
+        var options = new DbContextOptionsBuilder<GroceryDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        using var context = new GroceryDbContext(options);
+        var service = new GroceryItemService(context);
+        string itemName = "Cheddar cheese";
+        decimal price = 12m;
+        string description = "Yellow and delicious";
+        
+        var item = await service.CreateGroceryItemAsync(itemName, price, description);
+        Assert.NotNull(item);
+        var item2 = await service.CreateGroceryItemAsync(itemName, price, description);
+        Assert.Null(item2);
+
+    }
+
 }


### PR DESCRIPTION
- Implemented GroceryItemService with support for creating grocery items
- Includes EF Core in-memory testing and validation logic
- Added tests for successful creation, duplicate protection, and invalid categories
- No API endpoints yet—this is service-layer only