### PR TITLE
feat: addd groceryCompanyItem service with basic creation validation

### DIFF
--- a/src/GroceryApi/Data/GroceryCompanyItem.cs
+++ b/src/GroceryApi/Data/GroceryCompanyItem.cs
@@ -7,7 +7,7 @@ public class GroceryCompanyItem
     public GroceryItem GroceryItem { get; set; } = null!;
     public int CompanyId { get; set; }
     public GroceryCompany Company { get; set; } = null!;
-    public double? Price { get; set; }
+    public decimal? Price { get; set; }
     public required DateTime CreatedDate { get; set; }
     public required DateTime ModifiedDate { get; set; }
 }

--- a/src/GroceryApi/Data/GroceryCompanyItem.cs
+++ b/src/GroceryApi/Data/GroceryCompanyItem.cs
@@ -1,0 +1,13 @@
+namespace GroceryApi.Data;
+
+public class GroceryCompanyItem
+{
+    public int Id { get; set; }
+    public int GroceryItemId { get; set; }
+    public GroceryItem GroceryItem { get; set; } = null!;
+    public int CompanyId { get; set; }
+    public GroceryCompany Company { get; set; } = null!;
+    public decimal? Price { get; set; }
+    public required DateTime CreatedDate { get; set; }
+    public required DateTime ModifiedDate { get; set; }
+}

--- a/src/GroceryApi/Data/GroceryCompanyItem.cs
+++ b/src/GroceryApi/Data/GroceryCompanyItem.cs
@@ -7,7 +7,7 @@ public class GroceryCompanyItem
     public GroceryItem GroceryItem { get; set; } = null!;
     public int CompanyId { get; set; }
     public GroceryCompany Company { get; set; } = null!;
-    public decimal? Price { get; set; }
+    public double? Price { get; set; }
     public required DateTime CreatedDate { get; set; }
     public required DateTime ModifiedDate { get; set; }
 }

--- a/src/GroceryApi/Data/GroceryDbContext.cs
+++ b/src/GroceryApi/Data/GroceryDbContext.cs
@@ -12,6 +12,7 @@ public class GroceryDbContext : DbContext
     public DbSet<GroceryCategory> GroceryCategories { get; set; }
     public DbSet<GroceryStore> GroceryStores { get; set; }
     public DbSet<GroceryCompany> GroceryCompanies { get; set; }
+    public DbSet<GroceryCompanyItem> GroceryCompanyItems { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/GroceryApi/Data/GroceryItem.cs
+++ b/src/GroceryApi/Data/GroceryItem.cs
@@ -1,13 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace GroceryApi.Data;
 
 public class GroceryItem
 {
     public int Id { get; set; }
-    public string Name { get; set; } = null!;
-    public decimal Price { get; set; }
-    public string Description { get; set; } = null!;
+
+    [MaxLength(255)] public string Name { get; set; } = null!;
+
+    [MaxLength(5000)] public string Description { get; set; } = null!;
+
     public int? CategoryId { get; set; } = null;
     public GroceryCategory? Category { get; set; } = null;
-    
-
+    public DateTime CreatedDate { get; set; }
+    public DateTime ModifiedDate { get; set; }
 }

--- a/src/GroceryApi/Services/GroceryCompanyItemService.cs
+++ b/src/GroceryApi/Services/GroceryCompanyItemService.cs
@@ -30,7 +30,8 @@ public class GroceryCompanyItemService
         bool itemExists = await _context.GroceryCompanyItems
             .AnyAsync(x => x.CompanyId == companyId && x.GroceryItemId == groceryItemId);
         bool groceryItemExists = await _context.GroceryItems.AnyAsync(g => g.Id == groceryItemId);
-        if (itemExists || !groceryItemExists)
+        bool groceryCompanyExists = await _context.GroceryCompanies.AnyAsync(g => g.Id == companyId);
+        if (itemExists || !groceryItemExists || !groceryCompanyExists)
         {
             return null;
         }

--- a/src/GroceryApi/Services/GroceryCompanyItemService.cs
+++ b/src/GroceryApi/Services/GroceryCompanyItemService.cs
@@ -1,4 +1,5 @@
 using GroceryApi.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace GroceryApi.Services;
 
@@ -25,6 +26,13 @@ public class GroceryCompanyItemService
             CreatedDate = createdDate,
             ModifiedDate = createdDate
         };
+
+        bool itemExists = await _context.GroceryCompanyItems
+            .AnyAsync(x => x.CompanyId == companyId && x.GroceryItemId == groceryItemId);
+        if (itemExists)
+        {
+            return null;
+        }
 
         await _context.GroceryCompanyItems.AddAsync(groceryCompanyItem);
         await _context.SaveChangesAsync();

--- a/src/GroceryApi/Services/GroceryCompanyItemService.cs
+++ b/src/GroceryApi/Services/GroceryCompanyItemService.cs
@@ -13,8 +13,21 @@ public class GroceryCompanyItemService
         _context = context;
     }
 
-    public async Task<GroceryCompanyItem?> CreateGroceryCompanyItemAsync()
+    public async Task<GroceryCompanyItem?> CreateGroceryCompanyItemAsync(int companyId, int groceryItemId,
+        double? price)
     {
-        throw new NotImplementedException();
+        DateTime createdDate = DateTime.Now;
+        GroceryCompanyItem groceryCompanyItem = new GroceryCompanyItem()
+        {
+            CompanyId = companyId,
+            GroceryItemId = groceryItemId,
+            Price = price,
+            CreatedDate = createdDate,
+            ModifiedDate = createdDate
+        };
+
+        await _context.GroceryCompanyItems.AddAsync(groceryCompanyItem);
+        await _context.SaveChangesAsync();
+        return groceryCompanyItem;
     }
 }

--- a/src/GroceryApi/Services/GroceryCompanyItemService.cs
+++ b/src/GroceryApi/Services/GroceryCompanyItemService.cs
@@ -31,7 +31,7 @@ public class GroceryCompanyItemService
             .AnyAsync(x => x.CompanyId == companyId && x.GroceryItemId == groceryItemId);
         bool groceryItemExists = await _context.GroceryItems.AnyAsync(g => g.Id == groceryItemId);
         bool groceryCompanyExists = await _context.GroceryCompanies.AnyAsync(g => g.Id == companyId);
-        if (itemExists || !groceryItemExists || !groceryCompanyExists)
+        if (itemExists || !groceryItemExists || !groceryCompanyExists || groceryCompanyItem.Price < 0)
         {
             return null;
         }

--- a/src/GroceryApi/Services/GroceryCompanyItemService.cs
+++ b/src/GroceryApi/Services/GroceryCompanyItemService.cs
@@ -1,0 +1,20 @@
+using GroceryApi.Data;
+
+namespace GroceryApi.Services;
+
+public class GroceryCompanyItemService
+{
+    private readonly GroceryDbContext _context;
+    private readonly ILogger<GroceryCompanyItemService> _logger;
+
+    public GroceryCompanyItemService(ILogger<GroceryCompanyItemService> logger, GroceryDbContext context)
+    {
+        _logger = logger;
+        _context = context;
+    }
+
+    public async Task<GroceryCompanyItem?> CreateGroceryCompanyItemAsync()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/GroceryApi/Services/GroceryCompanyItemService.cs
+++ b/src/GroceryApi/Services/GroceryCompanyItemService.cs
@@ -14,7 +14,7 @@ public class GroceryCompanyItemService
     }
 
     public async Task<GroceryCompanyItem?> CreateGroceryCompanyItemAsync(int companyId, int groceryItemId,
-        double? price)
+        decimal? price)
     {
         DateTime createdDate = DateTime.Now;
         GroceryCompanyItem groceryCompanyItem = new GroceryCompanyItem()

--- a/src/GroceryApi/Services/GroceryCompanyItemService.cs
+++ b/src/GroceryApi/Services/GroceryCompanyItemService.cs
@@ -29,7 +29,8 @@ public class GroceryCompanyItemService
 
         bool itemExists = await _context.GroceryCompanyItems
             .AnyAsync(x => x.CompanyId == companyId && x.GroceryItemId == groceryItemId);
-        if (itemExists)
+        bool groceryItemExists = await _context.GroceryItems.AnyAsync(g => g.Id == groceryItemId);
+        if (itemExists || !groceryItemExists)
         {
             return null;
         }

--- a/src/GroceryApi/Services/GroceryItemService.cs
+++ b/src/GroceryApi/Services/GroceryItemService.cs
@@ -12,30 +12,25 @@ public class GroceryItemService
         _context = context;
     }
 
-    public async Task<GroceryItem?> CreateGroceryItemAsync(string name, decimal price, string description,
+    public async Task<GroceryItem?> CreateGroceryItemAsync(string name, string description,
         int? categoryId = null)
     {
-        GroceryItem? groceryItem = new GroceryItem
+        var groceryItem = new GroceryItem
         {
             Name = name,
-            Price = price,
             Description = description,
-            CategoryId = categoryId,
+            CategoryId = categoryId
         };
-        
+
         //Check constraints
-        var itemExists = await _context.GroceryItems.AnyAsync(i => 
-            i.Name == groceryItem.Name && i.Price == groceryItem.Price);
-        var categoryExists = await _context.GroceryCategories.AnyAsync(i => 
+        var itemExists = await _context.GroceryItems.AnyAsync(i =>
+            i.Name == groceryItem.Name);
+        var categoryExists = await _context.GroceryCategories.AnyAsync(i =>
             i.Id == groceryItem.CategoryId);
-        
-        if (itemExists || (!categoryExists&& categoryId.HasValue))
-        {
-            return null;
-        }
-        await  _context.AddAsync(groceryItem);
+
+        if (itemExists || (!categoryExists && categoryId.HasValue)) return null;
+        await _context.AddAsync(groceryItem);
         await _context.SaveChangesAsync();
         return groceryItem;
     }
-    
 }

--- a/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
+++ b/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
@@ -141,4 +141,43 @@ public class GroceryCompanyItemServiceTests
         GroceryCompanyItem? companyItem = await service.CreateGroceryCompanyItemAsync(companyId, groceryItemId, null);
         Assert.Null(companyItem);
     }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("-1000.1")]
+    [InlineData("-0.0000000000000001")]
+    [InlineData("-99999999999999999999999")]
+    public async Task CreateGroceryCompanyItem_WithNegativePrice_ReturnsNull(string? priceString)
+    {
+        decimal? price = priceString != null ? decimal.Parse(priceString) : null;
+        var context = UnitTestUtil.CreatInMemoryDbContext();
+        var companyId = 1;
+        var groceryItemId = 1;
+        ILogger<GroceryCompanyItemService> logger = new Mock<ILogger<GroceryCompanyItemService>>().Object;
+
+        GroceryCompany company = new GroceryCompany()
+        {
+            Id = companyId,
+            Name = "Grocery Company",
+        };
+        await context.GroceryCompanies.AddAsync(company);
+
+        GroceryItem groceryItem = new GroceryItem()
+        {
+            Id = groceryItemId,
+            Name = "Grocery Item",
+            Category = null,
+            CategoryId = null,
+            Description = "A grocery item",
+            CreatedDate = DateTime.Now,
+            ModifiedDate = DateTime.Now
+        };
+        await context.GroceryItems.AddAsync(groceryItem);
+        await context.SaveChangesAsync();
+
+        var service = new GroceryCompanyItemService(logger, context);
+        var groceryCompanyItem = await service.CreateGroceryCompanyItemAsync(companyId, groceryItemId, price);
+
+        Assert.Null(groceryCompanyItem);
+    }
 }

--- a/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
+++ b/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
@@ -9,11 +9,12 @@ public class GroceryCompanyItemServiceTests
 {
     [Theory]
     [InlineData(null)]
-    [InlineData(1.0)]
-    [InlineData(0.0)]
-    [InlineData(0.000000000000000000000000001)]
-    public async Task CreateGroceryCompanyItem_WithValidData_ReturnsGroceryCompanyItem(double? price)
+    [InlineData("1.0")]
+    [InlineData("0.0")]
+    [InlineData("0.000000000000000000000000001")]
+    public async Task CreateGroceryCompanyItem_WithValidData_ReturnsGroceryCompanyItem(string? priceString)
     {
+        decimal? price = priceString != null ? decimal.Parse(priceString) : null;
         var context = UnitTestUtil.CreatInMemoryDbContext();
         var companyId = 1;
         var groceryItemId = 1;
@@ -43,7 +44,7 @@ public class GroceryCompanyItemServiceTests
         var groceryCompanyItem = await service.CreateGroceryCompanyItemAsync(companyId, groceryItemId, price);
 
         Assert.NotNull(groceryCompanyItem);
-        Assert.NotNull(groceryCompanyItem.Id);
+        Assert.True(groceryCompanyItem.Id > 0);
         Assert.Equal(groceryCompanyItem.CompanyId, companyId);
         Assert.Equal(groceryCompanyItem.GroceryItemId, groceryItemId);
         Assert.Equal(groceryCompanyItem.Price, price);
@@ -51,12 +52,14 @@ public class GroceryCompanyItemServiceTests
 
     [Theory]
     [InlineData(null, null)]
-    [InlineData(1.0, 1.0)]
-    [InlineData(0.0, null)]
-    [InlineData(null, 0.0)]
-    [InlineData(double.MaxValue, 0.0)]
-    public async Task CreateGroceryCompanyItem_WithDuplicateData_ReturnsNull(double? price, double? price2)
+    [InlineData("1.0", "1.0")]
+    [InlineData("0.0", null)]
+    [InlineData(null, "0.0")]
+    [InlineData("100000000000.0", "0")]
+    public async Task CreateGroceryCompanyItem_WithDuplicateData_ReturnsNull(string? priceString, string? priceString2)
     {
+        decimal? price = priceString != null ? decimal.Parse(priceString) : null;
+        decimal? price2 = priceString2 != null ? decimal.Parse(priceString2) : null;
         var context = UnitTestUtil.CreatInMemoryDbContext();
         ILogger<GroceryCompanyItemService> logger = new Mock<ILogger<GroceryCompanyItemService>>().Object;
 

--- a/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
+++ b/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
@@ -92,4 +92,28 @@ public class GroceryCompanyItemServiceTests
             await service.CreateGroceryCompanyItemAsync(companyId, groceryItemId, price2);
         Assert.Null(companyItemDupe);
     }
+
+    [Fact]
+    public async Task CreateGroceryCompanyItem_WithInvalidGroceryItem_ReturnsNull()
+    {
+        var context = UnitTestUtil.CreatInMemoryDbContext();
+        ILogger<GroceryCompanyItemService> logger = new Mock<ILogger<GroceryCompanyItemService>>().Object;
+
+        var companyId = 1;
+        var groceryItemId = 1;
+
+        GroceryCompany company = new GroceryCompany()
+        {
+            Id = companyId,
+            Name = "Grocery Company",
+        };
+        await context.GroceryCompanies.AddAsync(company);
+
+        await context.SaveChangesAsync();
+        var service = new GroceryCompanyItemService(logger, context);
+
+        GroceryCompanyItem? companyItem = await service.CreateGroceryCompanyItemAsync(companyId, groceryItemId, null);
+
+        Assert.Null(companyItem);
+    }
 }

--- a/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
+++ b/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
@@ -116,4 +116,29 @@ public class GroceryCompanyItemServiceTests
 
         Assert.Null(companyItem);
     }
+
+    [Fact]
+    public async Task CreateGroceryCompanyItem_WithInvalidGroceryCompany_ReturnsNull()
+    {
+        var context = UnitTestUtil.CreatInMemoryDbContext();
+        ILogger<GroceryCompanyItemService> logger = new Mock<ILogger<GroceryCompanyItemService>>().Object;
+
+        var companyId = 1;
+        var groceryItemId = 1;
+
+        GroceryItem groceryItem = new GroceryItem()
+        {
+            Name = "Grocery Item",
+            CategoryId = null,
+            Description = "A grocery item",
+            CreatedDate = DateTime.Now,
+            ModifiedDate = DateTime.Now
+        };
+        await context.GroceryItems.AddAsync(groceryItem);
+        await context.SaveChangesAsync();
+        var service = new GroceryCompanyItemService(logger, context);
+
+        GroceryCompanyItem? companyItem = await service.CreateGroceryCompanyItemAsync(companyId, groceryItemId, null);
+        Assert.Null(companyItem);
+    }
 }

--- a/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
+++ b/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
@@ -1,0 +1,50 @@
+using GroceryApi.Data;
+using GroceryApi.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace GroceryApi.Tests.UnitTests;
+
+public class GroceryCompanyItemServiceTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    [InlineData(0)]
+    [InlineData(0.0000000000000000000000000001)]
+    public async Task CreateGroceryCompanyItem_WithValidData_ReturnsGroceryCompanyItem(decimal? price)
+    {
+        var context = UnitTestUtil.CreatInMemoryDbContext();
+        var companyId = 1;
+        var groceryItemId = 1;
+        ILogger<GroceryCompanyItemService> logger = new Mock<ILogger<GroceryCompanyItemService>>().Object;
+
+        GroceryCompany company = new GroceryCompany()
+        {
+            Id = companyId,
+            Name = "Grocery Company",
+        };
+        await context.GroceryCompanies.AddAsync(company);
+
+        GroceryItem groceryItem = new GroceryItem()
+        {
+            Id = groceryItemId,
+            Name = "Grocery Item",
+            Category = null,
+            CategoryId = null,
+            Description = "A grocery item",
+            CreatedDate = DateTime.Now,
+            ModifiedDate = DateTime.Now
+        };
+        await context.GroceryItems.AddAsync(groceryItem);
+        await context.SaveChangesAsync();
+
+        var service = new GroceryCompanyItemService(logger, context);
+        var groceryCompanyItem = await service.CreateGroceryCompanyItemAsync();
+
+        Assert.NotNull(groceryCompanyItem);
+        Assert.Equal(groceryCompanyItem.CompanyId, companyId);
+        Assert.Equal(groceryCompanyItem.GroceryItemId, groceryItemId);
+        Assert.Equal(groceryCompanyItem.Price, price);
+    }
+}

--- a/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
+++ b/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
@@ -9,10 +9,10 @@ public class GroceryCompanyItemServiceTests
 {
     [Theory]
     [InlineData(null)]
-    [InlineData(1)]
-    [InlineData(0)]
-    [InlineData(0.0000000000000000000000000001)]
-    public async Task CreateGroceryCompanyItem_WithValidData_ReturnsGroceryCompanyItem(decimal? price)
+    [InlineData(1.0)]
+    [InlineData(0.0)]
+    [InlineData(0.000000000000000000000000001)]
+    public async Task CreateGroceryCompanyItem_WithValidData_ReturnsGroceryCompanyItem(double? price)
     {
         var context = UnitTestUtil.CreatInMemoryDbContext();
         var companyId = 1;
@@ -40,9 +40,10 @@ public class GroceryCompanyItemServiceTests
         await context.SaveChangesAsync();
 
         var service = new GroceryCompanyItemService(logger, context);
-        var groceryCompanyItem = await service.CreateGroceryCompanyItemAsync();
+        var groceryCompanyItem = await service.CreateGroceryCompanyItemAsync(companyId, groceryItemId, price);
 
         Assert.NotNull(groceryCompanyItem);
+        Assert.NotNull(groceryCompanyItem.Id);
         Assert.Equal(groceryCompanyItem.CompanyId, companyId);
         Assert.Equal(groceryCompanyItem.GroceryItemId, groceryItemId);
         Assert.Equal(groceryCompanyItem.Price, price);

--- a/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
+++ b/tests/GroceryApi.Tests/UnitTests/GroceryCompanyItemServiceTests.cs
@@ -48,4 +48,45 @@ public class GroceryCompanyItemServiceTests
         Assert.Equal(groceryCompanyItem.GroceryItemId, groceryItemId);
         Assert.Equal(groceryCompanyItem.Price, price);
     }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(1.0, 1.0)]
+    [InlineData(0.0, null)]
+    [InlineData(null, 0.0)]
+    [InlineData(double.MaxValue, 0.0)]
+    public async Task CreateGroceryCompanyItem_WithDuplicateData_ReturnsNull(double? price, double? price2)
+    {
+        var context = UnitTestUtil.CreatInMemoryDbContext();
+        ILogger<GroceryCompanyItemService> logger = new Mock<ILogger<GroceryCompanyItemService>>().Object;
+
+        var companyId = 1;
+        var groceryItemId = 1;
+
+        GroceryCompany company = new GroceryCompany()
+        {
+            Id = companyId,
+            Name = "Grocery Company",
+        };
+        await context.GroceryCompanies.AddAsync(company);
+
+        GroceryItem groceryItem = new GroceryItem()
+        {
+            Id = groceryItemId,
+            Name = "Grocery Item",
+            CategoryId = null,
+            Description = "A grocery item",
+            CreatedDate = DateTime.Now,
+            ModifiedDate = DateTime.Now
+        };
+        await context.GroceryItems.AddAsync(groceryItem);
+        await context.SaveChangesAsync();
+        var service = new GroceryCompanyItemService(logger, context);
+
+        GroceryCompanyItem? companyItem = await service.CreateGroceryCompanyItemAsync(companyId, groceryItemId, price);
+        Assert.NotNull(companyItem);
+        GroceryCompanyItem? companyItemDupe =
+            await service.CreateGroceryCompanyItemAsync(companyId, groceryItemId, price2);
+        Assert.Null(companyItemDupe);
+    }
 }

--- a/tests/GroceryApi.Tests/UnitTests/GroceryItemServiceTests.cs
+++ b/tests/GroceryApi.Tests/UnitTests/GroceryItemServiceTests.cs
@@ -1,5 +1,6 @@
 using GroceryApi.Data;
 using GroceryApi.Services;
+using Microsoft.EntityFrameworkCore;
 
 namespace GroceryApi.Tests.UnitTests;
 
@@ -11,15 +12,15 @@ public class GroceryItemServiceTests
         using var context = UnitTestUtil.CreatInMemoryDbContext();
         var service = new GroceryItemService(context);
         string itemName = "Cheddar cheese";
-        decimal price = 12m;
         string description = "Yellow and delicious";
 
-        GroceryItem? groceryItem = await service.CreateGroceryItemAsync(itemName, price, description);
+        GroceryItem? groceryItem = await service.CreateGroceryItemAsync(itemName, description);
         Assert.NotNull(groceryItem);
-
         Assert.Equal(groceryItem.Name, itemName);
-        Assert.Equal(groceryItem.Price, price);
         Assert.Equal(groceryItem.Description, description);
+        bool isInContext = await context.GroceryItems.AnyAsync(x =>
+            x.Name == itemName && x.Description == description && x.Id == groceryItem.Id);
+        Assert.True(isInContext);
     }
 
     [Fact]
@@ -28,12 +29,11 @@ public class GroceryItemServiceTests
         using var context = UnitTestUtil.CreatInMemoryDbContext();
         var service = new GroceryItemService(context);
         string itemName = "Cheddar cheese";
-        decimal price = 12m;
         string description = "Yellow and delicious";
 
-        var item = await service.CreateGroceryItemAsync(itemName, price, description);
+        var item = await service.CreateGroceryItemAsync(itemName, description);
         Assert.NotNull(item);
-        var item2 = await service.CreateGroceryItemAsync(itemName, price, description);
+        var item2 = await service.CreateGroceryItemAsync(itemName, description);
         Assert.Null(item2);
     }
 
@@ -43,10 +43,12 @@ public class GroceryItemServiceTests
         using var context = UnitTestUtil.CreatInMemoryDbContext();
         var service = new GroceryItemService(context);
         string itemName = "Cheddar cheese";
-        decimal price = 12m;
         string description = "Yellow and delicious";
-        var item = await service.CreateGroceryItemAsync(itemName, price, description, categoryId: null);
+        var item = await service.CreateGroceryItemAsync(itemName, description, categoryId: null);
         Assert.NotNull(item);
+        var isInContext = await context.GroceryItems
+            .AnyAsync(x => x.Name == itemName && x.Description == description && x.Id == item.Id);
+        Assert.True(isInContext);
     }
 
     [Fact]
@@ -55,10 +57,9 @@ public class GroceryItemServiceTests
         using var context = UnitTestUtil.CreatInMemoryDbContext();
         var service = new GroceryItemService(context);
         string itemName = "Cheddar cheese";
-        decimal price = 12m;
         string description = "Yellow and delicious";
         int cateogryId = 1;
-        var item = await service.CreateGroceryItemAsync(itemName, price, description, cateogryId);
+        var item = await service.CreateGroceryItemAsync(itemName, description, cateogryId);
         Assert.Null(item);
     }
 }


### PR DESCRIPTION
-Implemented GroceryCompanyItemService with support for creating grocery company's items.
-Includes in-memory EF Core testing and validation logic
-Added tests for successful creation, duplicates, invalid companyIds.
-Another addition to the service layer